### PR TITLE
Add HTML export button

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ El archivo `pages/canvas.js` implementa un editor de formas basado en la etiquet
    texto su contenido, tamaño y color de fuente.
 3. Guardar el diseño en un archivo JSON o cargar un archivo existente para
    continuar editando.
+4. Exportar el diseño como un archivo HTML con la imagen resultante del canvas.

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -252,6 +252,28 @@ export default function CanvasPage() {
     URL.revokeObjectURL(url);
   };
 
+  const saveHTML = () => {
+    const canvas = canvasRef.current;
+    const dataUrl = canvas.toDataURL('image/png');
+    const htmlContent = `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Dise\u00f1o Canvas</title>
+</head>
+<body>
+  <img src="${dataUrl}" alt="Dise\u00f1o Canvas" />
+</body>
+</html>`;
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'design.html';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   const updateCurrent = (field, value) => {
     setCurrent({ ...current, [field]: value });
   };
@@ -358,6 +380,7 @@ export default function CanvasPage() {
         <button onClick={addShape}>Agregar</button>
         <hr />
         <button onClick={saveJSON}>Guardar JSON</button>
+        <button onClick={saveHTML}>Guardar HTML</button>
         <input type="file" accept="application/json" onChange={loadJSON} />
       </div>
       <canvas ref={canvasRef} width={800} height={600} style={{ border: '1px solid black', margin: '10px' }} />


### PR DESCRIPTION
## Summary
- generate an HTML page from the canvas design
- add button in the canvas editor
- document HTML export option in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fba19ef4832381d11d47bd598754