### PR TITLE
Add drag-based shape creation with selection handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ El archivo `pages/canvas.js` implementa un editor de formas basado en la etiquet
    texto su contenido, tamaño y color de fuente.
 3. Guardar el diseño en un archivo JSON o cargar un archivo existente para
    continuar editando.
-4. Cambiar el tamaño de las figuras manteniendo presionada la tecla **Shift** mientras las arrastras con el ratón.
+4. Las figuras se crean arrastrando sobre el lienzo al igual que las imágenes. Al seleccionar un objeto aparece un cuadro de selección con manejadores en las esquinas para cambiar su tamaño y un controlador para rotarlo.


### PR DESCRIPTION
## Summary
- allow drawing shapes by dragging on the canvas
- show selection box with resize and rotation handles
- update README to describe the new interaction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842000128088323b3079ea3f9309040