### PR TITLE
Add corner-based resizing

### DIFF
--- a/utils/shapes.js
+++ b/utils/shapes.js
@@ -8,6 +8,14 @@ export const pointToShape = (shape, px, py) => {
   };
 };
 
+export const shapeToPoint = (shape, px, py) => {
+  const angle = (shape.rotation * Math.PI) / 180;
+  return {
+    x: shape.x + px * Math.cos(angle) - py * Math.sin(angle),
+    y: shape.y + px * Math.sin(angle) + py * Math.cos(angle),
+  };
+};
+
 export const bounds = (shape) => {
   const w = shape.width || shape.radius * 2 || shape.fontSize * (shape.text?.length || 1);
   const h = shape.height || shape.radius * 2 || shape.fontSize;


### PR DESCRIPTION
## Summary
- add `shapeToPoint` to convert local coordinates to canvas coordinates
- store anchor position when starting a resize
- adjust resizing logic to work from that anchor and handle rotation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684206ed7af48323b080003fbfe51bfe