### PR TITLE
Add canvas page format options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ El archivo `pages/canvas.js` implementa un editor de formas basado en la etiquet
 4. Las figuras se crean arrastrando sobre el lienzo al igual que las imágenes. Al seleccionar un objeto aparece un cuadro de selección con manejadores en las esquinas para cambiar su tamaño y un controlador para rotarlo.
 5. Puedes aumentar o reducir su tamaño usando los nuevos botones de "Aumentar Tamaño" y "Reducir Tamaño".
 6. Exportar el contenido del lienzo a **PDF** o **HTML** desde los botones correspondientes.
+7. Cambiar el tamaño del lienzo a formatos de página estándar como **Carta**, **Legal**, **A4** o **A3**.

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -49,6 +49,9 @@ export default function CanvasPage() {
   const [rotateId, setRotateId] = useState(null);
   const [rotateStart, setRotateStart] = useState(null);
   const [previewShape, setPreviewShape] = useState(null);
+  const [canvasWidth, setCanvasWidth] = useState(800);
+  const [canvasHeight, setCanvasHeight] = useState(600);
+  const [formatName, setFormatName] = useState('');
 
 
   useEffect(() => {
@@ -63,7 +66,7 @@ export default function CanvasPage() {
       drawShape(ctx, previewShape);
       ctx.globalAlpha = 1;
     }
-  }, [shapes, previewShape, selectedId]);
+  }, [shapes, previewShape, selectedId, canvasWidth, canvasHeight]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -423,6 +426,22 @@ export default function CanvasPage() {
     { type: 'text', icon: <TbTypography /> },
   ];
 
+  const paperFormats = [
+    { name: 'Carta', width: 816, height: 1056 },
+    { name: 'Legal', width: 816, height: 1344 },
+    { name: 'A4', width: 794, height: 1123 },
+    { name: 'A3', width: 1123, height: 1587 },
+  ];
+
+  const handleFormatChange = (e) => {
+    const fmt = paperFormats.find((f) => f.name === e.target.value);
+    if (fmt) {
+      setCanvasWidth(fmt.width);
+      setCanvasHeight(fmt.height);
+      setFormatName(fmt.name);
+    }
+  };
+
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
       <div style={{ width: '250px', padding: '10px', overflowY: 'auto' }}>
@@ -530,8 +549,28 @@ export default function CanvasPage() {
           </div>
         )}
         <input type="file" accept="application/json" onChange={loadJSON} />
+        <div style={{ marginTop: '10px' }}>
+          <label>
+            Tamaño Página:
+            <select onChange={handleFormatChange} value={formatName}>
+              <option value="" disabled>
+                Seleccionar formato
+              </option>
+              {paperFormats.map((fmt) => (
+                <option key={fmt.name} value={fmt.name}>
+                  {fmt.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </div>
-      <canvas ref={canvasRef} width={800} height={600} style={{ border: '1px solid black', margin: '10px' }} />
+      <canvas
+        ref={canvasRef}
+        width={canvasWidth}
+        height={canvasHeight}
+        style={{ border: '1px solid black', margin: '10px' }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow switching canvas size to standard page formats
- document new size option in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684209e6c9ac83238bade14a47b391e4