### PR TITLE
Fix click detection after canvas resize

### DIFF
--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -72,7 +72,12 @@ export default function CanvasPage() {
     const canvas = canvasRef.current;
     const getPos = (e) => {
       const rect = canvas.getBoundingClientRect();
-      return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      const scaleX = canvas.width / rect.width;
+      const scaleY = canvas.height / rect.height;
+      return {
+        x: (e.clientX - rect.left) * scaleX,
+        y: (e.clientY - rect.top) * scaleY,
+      };
     };
     const hit = (shape, x, y) => {
       const { w, h } = bounds(shape);


### PR DESCRIPTION
## Summary
- adjust mouse position helper when canvas is scaled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68420dde42d88323add766ec8953d8fc