### PR TITLE
Fix selection box after property edits

### DIFF
--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -94,7 +94,7 @@ export default function CanvasPage() {
     } else {
       setSelectionBounds(null);
     }
-  }, [selectedId, shapes]);
+  }, [selectedId]);
 
   // Sync property controls with the selected shape
   useEffect(() => {
@@ -164,6 +164,7 @@ export default function CanvasPage() {
         const s = shapes[i];
         if (hit(s, x, y)) {
           setSelectedId(s.id);
+          setSelectionBounds(bounds(s));
           if (e.shiftKey) {
             setResizingId(s.id);
             setResizeStart({
@@ -183,6 +184,7 @@ export default function CanvasPage() {
         }
       }
       setSelectedId(null);
+      setSelectionBounds(null);
     };
     const handleMove = (e) => {
       const { x, y } = getPos(e);


### PR DESCRIPTION
## Summary
- preserve selection bounds when changing shape properties

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842524d01bc832380601cb2953e15c8