### PR TITLE
Add canvas thumbnail preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ El archivo `pages/canvas.js` implementa un editor de formas basado en la etiquet
 5. Puedes aumentar o reducir su tamaño usando los nuevos botones de "Aumentar Tamaño" y "Reducir Tamaño".
 6. Exportar el contenido del lienzo a **PDF** o **HTML** desde los botones correspondientes.
 7. Cambiar el tamaño del lienzo a formatos de página estándar como **Carta**, **Legal**, **A4** o **A3**.
+8. Generar una vista en miniatura del lienzo para previsualizar la página.
 
 ## Módulos
 
@@ -45,3 +46,4 @@ El proyecto se ha organizado en archivos de módulo ubicados en la carpeta `modu
 - `modules/impresion.js` contiene las funciones para exportar el lienzo a **PDF** y **HTML**.
 - `modules/figuras.js` agrupa la lógica de transformación y dibujo de las figuras sobre el canvas.
 - `modules/eliminacion.js` incluye utilidades para borrar uno o varios objetos del listado de formas.
+- `modules/thumbnail.js` permite obtener una miniatura del lienzo para previsualizaciones.

--- a/modules/thumbnail.js
+++ b/modules/thumbnail.js
@@ -1,0 +1,13 @@
+export function generateThumbnail(canvas, maxWidth = 200) {
+  if (!canvas) return null;
+  const scale = maxWidth / canvas.width;
+  const width = canvas.width * scale;
+  const height = canvas.height * scale;
+  const thumbCanvas = document.createElement('canvas');
+  thumbCanvas.width = width;
+  thumbCanvas.height = height;
+  const ctx = thumbCanvas.getContext('2d');
+  ctx.scale(scale, scale);
+  ctx.drawImage(canvas, 0, 0);
+  return thumbCanvas.toDataURL('image/png');
+}

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { savePDF, exportHTML } from '../modules/impresion';
+import { generateThumbnail } from '../modules/thumbnail';
 import { pointToShape, shapeToPoint, bounds, cornerHit, getCornerPos, drawShape } from '../modules/figuras';
 import { TbRectangle, TbSquare, TbCircle, TbTriangle, TbDiamond, TbPentagon, TbHexagon, TbOctagon, TbStar, TbArrowRight, TbHeart, TbTypography } from 'react-icons/tb';
 import { IoEllipse } from 'react-icons/io5';
@@ -68,6 +69,7 @@ export default function CanvasPage() {
   const [canvasHeight, setCanvasHeight] = useState(600);
   const [formatName, setFormatName] = useState('');
   const [selectionBounds, setSelectionBounds] = useState(null);
+  const [thumbnailUrl, setThumbnailUrl] = useState(null);
 
 
   useEffect(() => {
@@ -483,6 +485,11 @@ export default function CanvasPage() {
     exportHTML(canvasRef.current);
   };
 
+  const handleShowThumbnail = () => {
+    const url = generateThumbnail(canvasRef.current);
+    setThumbnailUrl(url);
+  };
+
   const resizeSelected = (delta) => {
     if (selectedId === null) return;
     setShapes((prev) =>
@@ -768,6 +775,9 @@ export default function CanvasPage() {
             <Button onClick={handleExportHTML} variant="outlined">
               Exportar HTML
             </Button>
+            <Button onClick={handleShowThumbnail} sx={{ mt: 1 }} variant="outlined">
+              Ver Miniatura
+            </Button>
             {selectedId !== null && (
               <Box sx={{ mt: 1 }}>
                 <Button onClick={() => resizeSelected(10)} sx={{ mr: 1 }} size="small" variant="contained">
@@ -806,6 +816,11 @@ export default function CanvasPage() {
         height={canvasHeight}
         style={{ border: '1px solid black', margin: '10px' }}
       />
+      {thumbnailUrl && (
+        <Box sx={{ ml: 2 }}>
+          <img src={thumbnailUrl} alt="Miniatura" style={{ border: '1px solid #ccc' }} />
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- show canvas preview by scaling canvas content
- expose `generateThumbnail` helper
- document miniature preview feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684252a756bc8323bd3eb3de9ad4eca8