### PR TITLE
Add page management to canvas

### DIFF
--- a/modules/paginas.js
+++ b/modules/paginas.js
@@ -1,0 +1,29 @@
+/**
+ * Funciones para manejar páginas en el editor de canvas.
+ */
+
+/**
+ * Crea una nueva página vacía.
+ * @param {number} width Ancho de la página.
+ * @param {number} height Alto de la página.
+ * @returns {Object} Objeto de página.
+ */
+export function crearPagina(width = 800, height = 600) {
+  return {
+    id: Date.now() + Math.random(),
+    width,
+    height,
+    shapes: []
+  };
+}
+
+/**
+ * Agrega una página vacía al arreglo existente.
+ * @param {Array} paginas Lista de páginas actuales.
+ * @param {number} width Ancho para la nueva página.
+ * @param {number} height Alto para la nueva página.
+ * @returns {Array} Nuevo arreglo de páginas con la añadida.
+ */
+export function agregarPagina(paginas, width = 800, height = 600) {
+  return [...paginas, crearPagina(width, height)];
+}

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -24,6 +24,7 @@ import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
+import { crearPagina, agregarPagina } from '../modules/paginas';
 
 const TrapezoidIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24">
@@ -74,6 +75,8 @@ export default function CanvasPage() {
   const [selectionBounds, setSelectionBounds] = useState(null);
   const [thumbnailUrl, setThumbnailUrl] = useState(null);
   const [contextMenu, setContextMenu] = useState(null);
+  const [pages, setPages] = useState([crearPagina(800, 600)]);
+  const [currentPage, setCurrentPage] = useState(0);
 
 
   useEffect(() => {
@@ -115,6 +118,27 @@ export default function CanvasPage() {
       }
     }
   }, [selectedId, shapes]);
+
+  // Cambia las formas y tamaño cuando se selecciona otra página
+  useEffect(() => {
+    const pg = pages[currentPage];
+    if (pg) {
+      setShapes(pg.shapes);
+      setCanvasWidth(pg.width);
+      setCanvasHeight(pg.height);
+    }
+  }, [currentPage]);
+
+  // Guarda automáticamente los cambios en la página actual
+  useEffect(() => {
+    setPages((prev) =>
+      prev.map((p, idx) =>
+        idx === currentPage
+          ? { ...p, shapes, width: canvasWidth, height: canvasHeight }
+          : p
+      )
+    );
+  }, [shapes, canvasWidth, canvasHeight]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -627,6 +651,19 @@ export default function CanvasPage() {
     }
   };
 
+  const handleAddPage = () => {
+    setPages((prev) => {
+      const updated = agregarPagina(prev, canvasWidth, canvasHeight);
+      setCurrentPage(updated.length - 1);
+      return updated;
+    });
+    setShapes([]);
+  };
+
+  const handlePageChange = (e) => {
+    setCurrentPage(parseInt(e.target.value));
+  };
+
   useEffect(() => {
     const handleKey = (e) => {
       if (e.key === 'Delete') {
@@ -884,6 +921,31 @@ export default function CanvasPage() {
                 ))}
               </Select>
             </FormControl>
+          </AccordionDetails>
+        </Accordion>
+        <Accordion defaultExpanded>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography>Páginas</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <FormControl fullWidth size="small">
+              <InputLabel id="page-label">Página</InputLabel>
+              <Select
+                labelId="page-label"
+                value={currentPage}
+                label="Página"
+                onChange={handlePageChange}
+              >
+                {pages.map((_, idx) => (
+                  <MenuItem key={idx} value={idx}>
+                    Página {idx + 1}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Button onClick={handleAddPage} sx={{ mt: 1 }} variant="contained" fullWidth>
+              Nueva Página
+            </Button>
           </AccordionDetails>
         </Accordion>
       </Box>


### PR DESCRIPTION
## Summary
- allow multiple pages in canvas
- add page management utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684257d457b48323baae94111bc84ad8