### PR TITLE
Enable multipage export

### DIFF
--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -524,11 +524,11 @@ export default function CanvasPage() {
   };
 
   const handleSavePDF = () => {
-    savePDF(canvasRef.current);
+    savePDF(pages);
   };
 
   const handleExportHTML = () => {
-    exportHTML(canvasRef.current);
+    exportHTML(pages);
   };
 
   const handleShowThumbnail = () => {


### PR DESCRIPTION
## Summary
- update `savePDF` and `exportHTML` to iterate all pages
- pass pages array instead of canvas when exporting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684259966eec83238facf39ae1edab8d