### PR TITLE
Set Carta as default page size

### DIFF
--- a/modules/paginas.js
+++ b/modules/paginas.js
@@ -8,7 +8,7 @@
  * @param {number} height Alto de la página.
  * @returns {Object} Objeto de página.
  */
-export function crearPagina(width = 800, height = 600) {
+export function crearPagina(width = 816, height = 1056) {
   return {
     id: Date.now() + Math.random(),
     width,
@@ -24,6 +24,6 @@ export function crearPagina(width = 800, height = 600) {
  * @param {number} height Alto para la nueva página.
  * @returns {Array} Nuevo arreglo de páginas con la añadida.
  */
-export function agregarPagina(paginas, width = 800, height = 600) {
+export function agregarPagina(paginas, width = 816, height = 1056) {
   return [...paginas, crearPagina(width, height)];
 }

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -69,13 +69,13 @@ export default function CanvasPage() {
   const [rotateId, setRotateId] = useState(null);
   const [rotateStart, setRotateStart] = useState(null);
   const [previewShape, setPreviewShape] = useState(null);
-  const [canvasWidth, setCanvasWidth] = useState(800);
-  const [canvasHeight, setCanvasHeight] = useState(600);
-  const [formatName, setFormatName] = useState('');
+  const [canvasWidth, setCanvasWidth] = useState(816);
+  const [canvasHeight, setCanvasHeight] = useState(1056);
+  const [formatName, setFormatName] = useState('Carta');
   const [selectionBounds, setSelectionBounds] = useState(null);
   const [thumbnailUrl, setThumbnailUrl] = useState(null);
   const [contextMenu, setContextMenu] = useState(null);
-  const [pages, setPages] = useState([crearPagina(800, 600)]);
+  const [pages, setPages] = useState([crearPagina(816, 1056)]);
   const [currentPage, setCurrentPage] = useState(0);
 
 
@@ -648,6 +648,9 @@ export default function CanvasPage() {
       setCanvasWidth(fmt.width);
       setCanvasHeight(fmt.height);
       setFormatName(fmt.name);
+      setPages((prev) =>
+        prev.map((p) => ({ ...p, width: fmt.width, height: fmt.height }))
+      );
     }
   };
 


### PR DESCRIPTION
## Summary
- update `crearPagina` and `agregarPagina` defaults to Carta dimensions
- make canvas default to Carta
- ensure all pages switch sizes when the format changes

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425bbcd7c48323b7be6a83318e3e03