### PR TITLE
Add menu bar component

### DIFF
--- a/components/MenuBar.js
+++ b/components/MenuBar.js
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+
+/**
+ * Barra de menú que agrupa acciones en "Archivo", "Edición" y "Vista".
+ * Cada acción se pasa mediante props para mantener el componente desacoplado.
+ */
+export default function MenuBar({
+  onSaveJSON,
+  onLoadJSON,
+  onSavePDF,
+  onExportHTML,
+  onResizePlus,
+  onResizeMinus,
+  onBringToFront,
+  onSendToBack,
+  onBringForward,
+  onSendBackward,
+  onDelete,
+  onAddPage,
+}) {
+  const [archivoAnchor, setArchivoAnchor] = useState(null);
+  const [edicionAnchor, setEdicionAnchor] = useState(null);
+  const [vistaAnchor, setVistaAnchor] = useState(null);
+
+  const openMenu = (setter) => (e) => setter(e.currentTarget);
+  const closeMenu = (setter) => () => setter(null);
+
+  return (
+    <AppBar position="static" color="default" sx={{ mb: 1 }}>
+      <Toolbar variant="dense">
+        <Button onClick={openMenu(setArchivoAnchor)}>Archivo</Button>
+        <Menu
+          anchorEl={archivoAnchor}
+          open={Boolean(archivoAnchor)}
+          onClose={closeMenu(setArchivoAnchor)}
+        >
+          <MenuItem onClick={() => { onSaveJSON?.(); setArchivoAnchor(null); }}>
+            Guardar JSON
+          </MenuItem>
+          <MenuItem onClick={() => { onLoadJSON?.(); setArchivoAnchor(null); }}>
+            Cargar JSON
+          </MenuItem>
+          <MenuItem onClick={() => { onSavePDF?.(); setArchivoAnchor(null); }}>
+            Guardar PDF
+          </MenuItem>
+          <MenuItem onClick={() => { onExportHTML?.(); setArchivoAnchor(null); }}>
+            Exportar HTML
+          </MenuItem>
+        </Menu>
+
+        <Button onClick={openMenu(setEdicionAnchor)}>Edición</Button>
+        <Menu
+          anchorEl={edicionAnchor}
+          open={Boolean(edicionAnchor)}
+          onClose={closeMenu(setEdicionAnchor)}
+        >
+          <MenuItem onClick={() => { onResizePlus?.(); setEdicionAnchor(null); }}>
+            Aumentar Tamaño
+          </MenuItem>
+          <MenuItem onClick={() => { onResizeMinus?.(); setEdicionAnchor(null); }}>
+            Reducir Tamaño
+          </MenuItem>
+          <MenuItem onClick={() => { onBringToFront?.(); setEdicionAnchor(null); }}>
+            Al Frente
+          </MenuItem>
+          <MenuItem onClick={() => { onSendToBack?.(); setEdicionAnchor(null); }}>
+            Al Fondo
+          </MenuItem>
+          <MenuItem onClick={() => { onBringForward?.(); setEdicionAnchor(null); }}>
+            Adelantar
+          </MenuItem>
+          <MenuItem onClick={() => { onSendBackward?.(); setEdicionAnchor(null); }}>
+            Atrasar
+          </MenuItem>
+          <MenuItem onClick={() => { onDelete?.(); setEdicionAnchor(null); }}>
+            Eliminar
+          </MenuItem>
+        </Menu>
+
+        <Button onClick={openMenu(setVistaAnchor)}>Vista</Button>
+        <Menu
+          anchorEl={vistaAnchor}
+          open={Boolean(vistaAnchor)}
+          onClose={closeMenu(setVistaAnchor)}
+        >
+          <MenuItem onClick={() => { onAddPage?.(); setVistaAnchor(null); }}>
+            Nueva Página
+          </MenuItem>
+        </Menu>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -37,6 +37,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
 import { crearPagina, agregarPagina } from '../modules/paginas';
+import MenuBar from '../components/MenuBar';
 
 const TrapezoidIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24">
@@ -47,6 +48,7 @@ const TrapezoidIcon = () => (
 export default function CanvasPage() {
   const canvasRef = useRef(null);
   const fileInputRef = useRef(null);
+  const jsonInputRef = useRef(null);
   const [shapes, setShapes] = useState([]);
   const [pendingImage, setPendingImage] = useState(null);
   const [drawingImage, setDrawingImage] = useState(false);
@@ -608,6 +610,13 @@ export default function CanvasPage() {
     }
   };
 
+  const handleLoadJSONClick = () => {
+    if (jsonInputRef.current) {
+      jsonInputRef.current.value = '';
+      jsonInputRef.current.click();
+    }
+  };
+
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -687,7 +696,22 @@ export default function CanvasPage() {
   }, [selectedId]);
 
   return (
-    <Box sx={{ display: 'flex', height: '100vh' }}>
+    <>
+      <MenuBar
+        onSaveJSON={saveJSON}
+        onLoadJSON={handleLoadJSONClick}
+        onSavePDF={handleSavePDF}
+        onExportHTML={handleExportHTML}
+        onResizePlus={() => resizeSelected(10)}
+        onResizeMinus={() => resizeSelected(-10)}
+        onBringToFront={bringSelectedToFront}
+        onSendToBack={sendSelectedToBack}
+        onBringForward={bringSelectedForward}
+        onSendBackward={sendSelectedBackward}
+        onDelete={deleteSelected}
+        onAddPage={handleAddPage}
+      />
+      <Box sx={{ display: 'flex', height: '100vh' }}>
       <Box sx={{ width: 250, p: 1, overflowY: 'auto' }}>
         <Accordion defaultExpanded>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -911,7 +935,13 @@ export default function CanvasPage() {
                 </Box>
               </>
             )}
-            <input type="file" accept="application/json" onChange={loadJSON} />
+            <input
+              type="file"
+              ref={jsonInputRef}
+              accept="application/json"
+              style={{ display: 'none' }}
+              onChange={loadJSON}
+            />
             <FormControl fullWidth sx={{ mt: 1 }} size="small">
               <InputLabel id="format-label">Tamaño Página</InputLabel>
               <Select
@@ -1040,5 +1070,6 @@ export default function CanvasPage() {
         </MenuItem>
       </Menu>
     </Box>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- create a reusable `MenuBar` component
- integrate `MenuBar` into the canvas page and hide JSON loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68425fd9b2dc832399a5d6b945b20496