### PR TITLE
Hide controls in canvas page

### DIFF
--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -750,7 +750,11 @@ export default function CanvasPage() {
               style={{ display: 'none' }}
               onChange={handleImageChange}
             />
-            <Button variant="contained" onClick={addShape} sx={{ mt: 1 }}>
+            <Button
+              variant="contained"
+              onClick={addShape}
+              sx={{ mt: 1, display: 'none' }}
+            >
               Agregar
             </Button>
           </AccordionDetails>
@@ -892,7 +896,7 @@ export default function CanvasPage() {
             )}
           </AccordionDetails>
         </Accordion>
-        <Accordion defaultExpanded>
+        <Accordion defaultExpanded sx={{ display: 'none' }}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography>Acciones</Typography>
           </AccordionSummary>
@@ -962,7 +966,7 @@ export default function CanvasPage() {
             </FormControl>
           </AccordionDetails>
         </Accordion>
-        <Accordion defaultExpanded>
+        <Accordion defaultExpanded sx={{ display: 'none' }}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography>Páginas</Typography>
           </AccordionSummary>


### PR DESCRIPTION
## Summary
- hide `Agregar` button from tools
- hide `Acciones` accordion
- hide `Páginas` accordion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842614149388323adfcd10ab052a39e