### PR TITLE
Add icons in menu

### DIFF
--- a/components/MenuBar.js
+++ b/components/MenuBar.js
@@ -4,6 +4,19 @@ import Toolbar from '@mui/material/Toolbar';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import SaveIcon from '@mui/icons-material/Save';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import CodeIcon from '@mui/icons-material/Code';
+import ZoomInIcon from '@mui/icons-material/ZoomIn';
+import ZoomOutIcon from '@mui/icons-material/ZoomOut';
+import FlipToFrontIcon from '@mui/icons-material/FlipToFront';
+import FlipToBackIcon from '@mui/icons-material/FlipToBack';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
 
 /**
  * Barra de menú que agrupa acciones en "Archivo", "Edición" y "Vista".
@@ -40,15 +53,27 @@ export default function MenuBar({
           onClose={closeMenu(setArchivoAnchor)}
         >
           <MenuItem onClick={() => { onSaveJSON?.(); setArchivoAnchor(null); }}>
+            <ListItemIcon>
+              <SaveIcon fontSize="small" />
+            </ListItemIcon>
             Guardar JSON
           </MenuItem>
           <MenuItem onClick={() => { onLoadJSON?.(); setArchivoAnchor(null); }}>
+            <ListItemIcon>
+              <FolderOpenIcon fontSize="small" />
+            </ListItemIcon>
             Cargar JSON
           </MenuItem>
           <MenuItem onClick={() => { onSavePDF?.(); setArchivoAnchor(null); }}>
+            <ListItemIcon>
+              <PictureAsPdfIcon fontSize="small" />
+            </ListItemIcon>
             Guardar PDF
           </MenuItem>
           <MenuItem onClick={() => { onExportHTML?.(); setArchivoAnchor(null); }}>
+            <ListItemIcon>
+              <CodeIcon fontSize="small" />
+            </ListItemIcon>
             Exportar HTML
           </MenuItem>
         </Menu>
@@ -60,24 +85,45 @@ export default function MenuBar({
           onClose={closeMenu(setEdicionAnchor)}
         >
           <MenuItem onClick={() => { onResizePlus?.(); setEdicionAnchor(null); }}>
+            <ListItemIcon>
+              <ZoomInIcon fontSize="small" />
+            </ListItemIcon>
             Aumentar Tamaño
           </MenuItem>
           <MenuItem onClick={() => { onResizeMinus?.(); setEdicionAnchor(null); }}>
+            <ListItemIcon>
+              <ZoomOutIcon fontSize="small" />
+            </ListItemIcon>
             Reducir Tamaño
           </MenuItem>
           <MenuItem onClick={() => { onBringToFront?.(); setEdicionAnchor(null); }}>
+            <ListItemIcon>
+              <FlipToFrontIcon fontSize="small" />
+            </ListItemIcon>
             Al Frente
           </MenuItem>
           <MenuItem onClick={() => { onSendToBack?.(); setEdicionAnchor(null); }}>
+            <ListItemIcon>
+              <FlipToBackIcon fontSize="small" />
+            </ListItemIcon>
             Al Fondo
           </MenuItem>
           <MenuItem onClick={() => { onBringForward?.(); setEdicionAnchor(null); }}>
+            <ListItemIcon>
+              <ArrowUpwardIcon fontSize="small" />
+            </ListItemIcon>
             Adelantar
           </MenuItem>
           <MenuItem onClick={() => { onSendBackward?.(); setEdicionAnchor(null); }}>
+            <ListItemIcon>
+              <ArrowDownwardIcon fontSize="small" />
+            </ListItemIcon>
             Atrasar
           </MenuItem>
           <MenuItem onClick={() => { onDelete?.(); setEdicionAnchor(null); }}>
+            <ListItemIcon>
+              <DeleteIcon fontSize="small" />
+            </ListItemIcon>
             Eliminar
           </MenuItem>
         </Menu>
@@ -89,6 +135,9 @@ export default function MenuBar({
           onClose={closeMenu(setVistaAnchor)}
         >
           <MenuItem onClick={() => { onAddPage?.(); setVistaAnchor(null); }}>
+            <ListItemIcon>
+              <AddIcon fontSize="small" />
+            </ListItemIcon>
             Nueva Página
           </MenuItem>
         </Menu>


### PR DESCRIPTION
## Summary
- add Material UI icons to every menu item so the text has an accompanying graphic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842665d1d60832382586bd2654d2ba8