### PR TITLE
Hide properties panel until object selected

### DIFF
--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -783,6 +783,7 @@ export default function CanvasPage() {
             </Button>
           </AccordionDetails>
         </Accordion>
+        {selectedId !== null && (
         <Accordion defaultExpanded>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography>Propiedades</Typography>
@@ -920,6 +921,7 @@ export default function CanvasPage() {
             )}
           </AccordionDetails>
         </Accordion>
+        )}
         <Accordion defaultExpanded sx={{ display: 'none' }}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography>Acciones</Typography>


### PR DESCRIPTION
## Summary
- show the Propiedades accordion only when a shape is selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842668bb4b083239eccd2a6e5e24f30