### PR TITLE
Add zoom buttons to canvas tools

### DIFF
--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -856,6 +856,12 @@ export default function CanvasPage() {
                   {opt.icon}
                 </IconButton>
               ))}
+              <IconButton onClick={zoomIn} title="Acercar">
+                <MdZoomIn />
+              </IconButton>
+              <IconButton onClick={zoomOut} title="Alejar">
+                <MdZoomOut />
+              </IconButton>
             </Box>
             <input
               type="file"


### PR DESCRIPTION
## Summary
- add zoom in and zoom out buttons in the canvas tools section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68426d3314488323a1e474044c03bb07