### PR TITLE
Integrate Clerk authentication

### DIFF
--- a/modules/clerk.js
+++ b/modules/clerk.js
@@ -1,7 +1,14 @@
+/**
+ * Opciones que se pasan al `ClerkProvider`.
+ * Todas las rutas se obtienen de variables de entorno para
+ * permitir configuraciones diferentes entre entornos.
+ */
 export const clerkOptions = {
   publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
-  signInUrl: process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,
-  signUpUrl: process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL,
-  afterSignInUrl: process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL,
-  afterSignUpUrl: process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL,
+  signInUrl: process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '/sign-in',
+  signUpUrl: process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '/sign-up',
+  afterSignInUrl: process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL || '/',
+  afterSignUpUrl: process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL || '/',
 };
+
+export default clerkOptions;

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -39,6 +39,8 @@ import Menu from '@mui/material/Menu';
 import { crearPagina, agregarPagina } from '../modules/paginas';
 import MenuBar from '../components/MenuBar';
 import useZoom from '../modules/zoom';
+import { useUser } from '@clerk/nextjs';
+import { getAuth } from '@clerk/nextjs/server';
 
 const TrapezoidIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24">
@@ -50,6 +52,8 @@ export default function CanvasPage() {
   const canvasRef = useRef(null);
   const fileInputRef = useRef(null);
   const jsonInputRef = useRef(null);
+  // Información del usuario autenticado
+  const { user } = useUser();
   const [shapes, setShapes] = useState([]);
   const [pendingImage, setPendingImage] = useState(null);
   const [drawingImage, setDrawingImage] = useState(false);
@@ -1241,4 +1245,18 @@ export default function CanvasPage() {
     </Box>
     </>
   );
+}
+
+// Protege la página para que solo usuarios autenticados puedan acceder
+export async function getServerSideProps(ctx) {
+  const { userId } = getAuth(ctx.req);
+  if (!userId) {
+    return {
+      redirect: {
+        destination: '/sign-in',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
 }

--- a/pages/sign-in.js
+++ b/pages/sign-in.js
@@ -1,0 +1,5 @@
+import { SignIn } from '@clerk/nextjs';
+
+export default function SignInPage() {
+  return <SignIn path="/sign-in" routing="path" />;
+}

--- a/pages/sign-up.js
+++ b/pages/sign-up.js
@@ -1,0 +1,5 @@
+import { SignUp } from '@clerk/nextjs';
+
+export default function SignUpPage() {
+  return <SignUp path="/sign-up" routing="path" />;
+}


### PR DESCRIPTION
## Summary
- set up Clerk options using env vars
- add Sign In and Sign Up pages
- secure `/canvas` with server-side Clerk auth and access user with the hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68427545d2148323974ada883f16ca38