### PR TITLE
Add Clerk logout option

### DIFF
--- a/components/MenuBar.js
+++ b/components/MenuBar.js
@@ -17,6 +17,7 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
+import LogoutIcon from '@mui/icons-material/Logout';
 
 /**
  * Barra de menú que agrupa acciones en "Archivo", "Edición" y "Vista".
@@ -27,6 +28,7 @@ export default function MenuBar({
   onLoadJSON,
   onSavePDF,
   onExportHTML,
+  onSignOut,
   onResizePlus,
   onResizeMinus,
   onBringToFront,
@@ -77,6 +79,12 @@ export default function MenuBar({
               <CodeIcon fontSize="small" />
             </ListItemIcon>
             Exportar HTML
+          </MenuItem>
+          <MenuItem onClick={() => { onSignOut?.(); setArchivoAnchor(null); }}>
+            <ListItemIcon>
+              <LogoutIcon fontSize="small" />
+            </ListItemIcon>
+            Cerrar Sesión
           </MenuItem>
         </Menu>
 

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -39,7 +39,7 @@ import Menu from '@mui/material/Menu';
 import { crearPagina, agregarPagina } from '../modules/paginas';
 import MenuBar from '../components/MenuBar';
 import useZoom from '../modules/zoom';
-import { useUser } from '@clerk/nextjs';
+import { useUser, useClerk } from '@clerk/nextjs';
 import { getAuth } from '@clerk/nextjs/server';
 
 const TrapezoidIcon = () => (
@@ -54,6 +54,7 @@ export default function CanvasPage() {
   const jsonInputRef = useRef(null);
   // Información del usuario autenticado
   const { user } = useUser();
+  const { signOut } = useClerk();
   const [shapes, setShapes] = useState([]);
   const [pendingImage, setPendingImage] = useState(null);
   const [drawingImage, setDrawingImage] = useState(false);
@@ -818,6 +819,7 @@ export default function CanvasPage() {
         onLoadJSON={handleLoadJSONClick}
         onSavePDF={handleSavePDF}
         onExportHTML={handleExportHTML}
+        onSignOut={signOut}
         onResizePlus={() => resizeSelected(10)}
         onResizeMinus={() => resizeSelected(-10)}
         onBringToFront={bringSelectedToFront}


### PR DESCRIPTION
## Summary
- allow MenuBar to trigger Clerk sign out
- expose signOut in canvas page and pass to `MenuBar`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68427b06a6c48323bae238e4ac9430e8