### PR TITLE
Add CMYK color editing

### DIFF
--- a/modules/cmyk.js
+++ b/modules/cmyk.js
@@ -1,0 +1,21 @@
+export function cmykToRgb(c, m, y, k) {
+  const c1 = c / 100;
+  const m1 = m / 100;
+  const y1 = y / 100;
+  const k1 = k / 100;
+  const r = Math.round(255 * (1 - c1) * (1 - k1));
+  const g = Math.round(255 * (1 - m1) * (1 - k1));
+  const b = Math.round(255 * (1 - y1) * (1 - k1));
+  return { r, g, b };
+}
+
+export function cmykToHex(c, m, y, k) {
+  const { r, g, b } = cmykToRgb(c, m, y, k);
+  const toHex = (n) => n.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+export function applyCmykColor(shapes, id, { c, m, y, k }, property = 'fillColor') {
+  const hex = cmykToHex(c, m, y, k);
+  return shapes.map((s) => (s.id === id ? { ...s, [property]: hex } : s));
+}

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -41,6 +41,7 @@ import MenuBar from '../components/MenuBar';
 import useZoom from '../modules/zoom';
 import { useUser, useClerk } from '@clerk/nextjs';
 import { getAuth } from '@clerk/nextjs/server';
+import { cmykToHex } from '../modules/cmyk';
 
 const TrapezoidIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24">
@@ -676,6 +677,13 @@ export default function CanvasPage() {
     }
   };
 
+  const updateColorCMYK = (field, value) => {
+    const parts = value.split(/[,\s]+/).map((n) => parseFloat(n));
+    if (parts.length !== 4 || parts.some((n) => isNaN(n))) return;
+    const hex = cmykToHex(parts[0], parts[1], parts[2], parts[3]);
+    updateCurrent(field, hex);
+  };
+
   const handleImageClick = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
@@ -965,6 +973,14 @@ export default function CanvasPage() {
               onChange={(e) => updateCurrent('fillColor', e.target.value)}
             />
             <TextField
+              label="CMYK Relleno"
+              size="small"
+              margin="dense"
+              placeholder="c m y k"
+              sx={{ width: 80 }}
+              onBlur={(e) => updateColorCMYK('fillColor', e.target.value)}
+            />
+            <TextField
               label="Color Borde"
               type="color"
               size="small"
@@ -972,6 +988,14 @@ export default function CanvasPage() {
               sx={{ width: 60 }}
               value={current.strokeColor}
               onChange={(e) => updateCurrent('strokeColor', e.target.value)}
+            />
+            <TextField
+              label="CMYK Borde"
+              size="small"
+              margin="dense"
+              placeholder="c m y k"
+              sx={{ width: 80 }}
+              onBlur={(e) => updateColorCMYK('strokeColor', e.target.value)}
             />
             <TextField
               label="Grosor Borde"


### PR DESCRIPTION
## Summary
- add CMYK color helpers
- allow editing selected shape colors with CMYK values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68473aaa12ec8323b67f250e4f294459