### PR TITLE
Add undo/redo

### DIFF
--- a/components/MenuBar.js
+++ b/components/MenuBar.js
@@ -39,6 +39,8 @@ export default function MenuBar({
   onAddPage,
   onZoomIn,
   onZoomOut,
+  onUndo,
+  onRedo,
 }) {
   const [archivoAnchor, setArchivoAnchor] = useState(null);
   const [edicionAnchor, setEdicionAnchor] = useState(null);
@@ -94,6 +96,12 @@ export default function MenuBar({
           open={Boolean(edicionAnchor)}
           onClose={closeMenu(setEdicionAnchor)}
         >
+          <MenuItem onClick={() => { onUndo?.(); setEdicionAnchor(null); }}>
+            Deshacer
+          </MenuItem>
+          <MenuItem onClick={() => { onRedo?.(); setEdicionAnchor(null); }}>
+            Rehacer
+          </MenuItem>
           <MenuItem onClick={() => { onResizePlus?.(); setEdicionAnchor(null); }}>
             <ListItemIcon>
               <ZoomInIcon fontSize="small" />

--- a/modules/history.js
+++ b/modules/history.js
@@ -1,0 +1,58 @@
+import { useState, useRef, useCallback } from 'react';
+
+/**
+ * Hook para manejar historial de deshacer/rehacer con un límite fijo.
+ * @param {any} initial Estado inicial.
+ * @param {number} limit Cantidad máxima de estados a almacenar.
+ */
+export default function useHistory(initial = [], limit = 4) {
+  const [state, setState] = useState(initial);
+  const undoStack = useRef([]);
+  const redoStack = useRef([]);
+  const skip = useRef(false);
+
+  const set = useCallback(
+    (updater) => {
+      setState((prev) => {
+        const next = typeof updater === 'function' ? updater(prev) : updater;
+        if (!skip.current) {
+          undoStack.current.push(prev);
+          if (undoStack.current.length > limit) undoStack.current.shift();
+          redoStack.current = [];
+        } else {
+          skip.current = false;
+        }
+        return next;
+      });
+    },
+    [limit]
+  );
+
+  const replace = useCallback((newState) => {
+    skip.current = true;
+    setState(newState);
+  }, []);
+
+  const undo = useCallback(() => {
+    if (undoStack.current.length === 0) return;
+    const prev = undoStack.current.pop();
+    redoStack.current.push(state);
+    if (redoStack.current.length > limit) redoStack.current.shift();
+    skip.current = true;
+    setState(prev);
+  }, [state, limit]);
+
+  const redo = useCallback(() => {
+    if (redoStack.current.length === 0) return;
+    const next = redoStack.current.pop();
+    undoStack.current.push(state);
+    if (undoStack.current.length > limit) undoStack.current.shift();
+    skip.current = true;
+    setState(next);
+  }, [state, limit]);
+
+  const canUndo = undoStack.current.length > 0;
+  const canRedo = redoStack.current.length > 0;
+
+  return { state, set, replace, undo, redo, canUndo, canRedo };
+}

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -39,6 +39,7 @@ import Menu from '@mui/material/Menu';
 import { crearPagina, agregarPagina } from '../modules/paginas';
 import MenuBar from '../components/MenuBar';
 import useZoom from '../modules/zoom';
+import useHistory from '../modules/history';
 import { useUser, useClerk } from '@clerk/nextjs';
 import { getAuth } from '@clerk/nextjs/server';
 import { cmykToHex } from '../modules/cmyk';
@@ -56,7 +57,7 @@ export default function CanvasPage() {
   // Información del usuario autenticado
   const { user } = useUser();
   const { signOut } = useClerk();
-  const [shapes, setShapes] = useState([]);
+  const { state: shapes, set: setShapes, replace: replaceShapes, undo, redo, canUndo, canRedo } = useHistory([]);
   const [pendingImage, setPendingImage] = useState(null);
   const [drawingImage, setDrawingImage] = useState(false);
   const [imageStart, setImageStart] = useState(null);
@@ -149,7 +150,7 @@ export default function CanvasPage() {
   useEffect(() => {
     const pg = pages[currentPage];
     if (pg) {
-      setShapes(pg.shapes);
+      replaceShapes(pg.shapes);
       setCanvasWidth(pg.width);
       setCanvasHeight(pg.height);
     }
@@ -555,7 +556,7 @@ export default function CanvasPage() {
         }
         return base;
       });
-      setShapes(loaded);
+      replaceShapes(loaded);
     };
     reader.readAsText(file);
   };
@@ -838,6 +839,8 @@ export default function CanvasPage() {
         onAddPage={handleAddPage}
         onZoomIn={zoomIn}
         onZoomOut={zoomOut}
+        onUndo={undo}
+        onRedo={redo}
       />
       <Box sx={{ display: 'flex', height: '100vh' }}>
       <Box sx={{ width: 250, p: 1, overflowY: 'auto' }}>


### PR DESCRIPTION
## Summary
- create `useHistory` hook to manage undo/redo history
- add undo and redo menu items in `MenuBar`
- integrate undo/redo in canvas page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684adb03bfd88323a8a23c83c882b845